### PR TITLE
adding github actions for tests on push

### DIFF
--- a/.github/workflows/github-actions-tests-on-windows.yml
+++ b/.github/workflows/github-actions-tests-on-windows.yml
@@ -1,13 +1,6 @@
 name: Tests on Windows
 
-on:
-  workflow_dispatch:
-  push:
-    branches: [master]
-    paths-ignore:
-      - '**.md'
-  pull_request:
-    branches: [master]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -25,4 +18,4 @@ jobs:
       - name: Build
         run: dotnet build --configuration Debug --no-restore
       - name: Test
-        run: dotnet test --no-build --no-restore --verbosity normal --filter ContentPopulated_When_GetAlbums
+        run: dotnet test --no-build --no-restore --verbosity normal --filter FullyQualifiedName=Bellatrix.API.Tests.ApiClientServiceNotAsyncRequestTests.ContentPopulated_When_GetAlbums

--- a/.github/workflows/github-actions-tests-on-windows.yml
+++ b/.github/workflows/github-actions-tests-on-windows.yml
@@ -1,0 +1,28 @@
+name: Tests on Windows
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        uses: actions/setup-dotnet@v1.7.2
+        with:
+          dotnet-version: '5.0.x'
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Debug --no-restore
+      - name: Test
+        run: dotnet test --no-build --no-restore --verbosity normal --filter ContentPopulated_When_GetAlbums


### PR DESCRIPTION
- added github action for running tests on windows. Innitiall filter set to API Tests only ContentPopulated_When_GetAlbums
- fixed the filter to execute only the APITest ContentPopulated_When_GetAlbums
