### PR TITLE
Added check for environment when taking the settings file

### DIFF
--- a/src/Bellatrix.Core/settings/ConfigurationService.cs
+++ b/src/Bellatrix.Core/settings/ConfigurationService.cs
@@ -49,9 +49,10 @@ public sealed class ConfigurationService
         var builder = new ConfigurationBuilder();
         var executionDir = ExecutionDirectoryResolver.GetDriverExecutablePath();
         var filesInExecutionDir = Directory.GetFiles(executionDir);
+        var configuration = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyConfigurationAttribute>().Configuration;
         var settingsFile =
 #pragma warning disable CA1310 // Specify StringComparison for correctness
-                filesInExecutionDir.FirstOrDefault(x => x.Contains("testFrameworkSettings") && x.EndsWith(".json"));
+                filesInExecutionDir.FirstOrDefault(x => x.Contains("testFrameworkSettings") && x.Contains(configuration) && x.EndsWith(".json"));
 #pragma warning restore CA1310 // Specify StringComparison for correctness
         if (settingsFile != null)
         {


### PR DESCRIPTION
Added additional check for the current environment, when taking the settings file.

Fix the issue, when there is more than one testFrameworkSettings.*.json file in the build folder.
Currently, it takes the first founded file.