### PR TITLE
Fixed file path, for loading emails

### DIFF
--- a/src/Bellatrix.Web/settings/ExecutionSettings.cs
+++ b/src/Bellatrix.Web/settings/ExecutionSettings.cs
@@ -23,6 +23,7 @@ public class ExecutionSettings
     public string DefaultLifeCycle { get; set; }
     public string Resolution { get; set; }
     public string Url { get; set; }
+    public string FileRemoteLocation { get; set; }
     public List<Dictionary<string, string>> Arguments { get; set; }
     public string PackedExtensionPath { get; set; }
     public string UnpackedExtensionPath { get; set; }

--- a/src/Bellatrix.Web/utilities/EmailService.cs
+++ b/src/Bellatrix.Web/utilities/EmailService.cs
@@ -55,7 +55,6 @@ public static class EmailService
         #if DEBUG || QA
         navigationService.NavigateToLocalPage(tempFilePath);
         #elif QASAFARI || QAFIREFOX
-        Logger.LogInformation("BrakePoint: 7 - QASafari");
         navigationService.Navigate($"{ConfigurationService.GetSection<WebSettings>().ExecutionSettings.FileRemoteLocation}{fileName}");
         #endif
 

--- a/src/Bellatrix.Web/utilities/EmailService.cs
+++ b/src/Bellatrix.Web/utilities/EmailService.cs
@@ -52,10 +52,11 @@ public static class EmailService
         File.WriteAllText(tempFilePath, htmlBody);
         var navigationService = ServicesCollection.Current.Resolve<NavigationService>();
 
-        #if DEBUG
+        #if DEBUG || QA
         navigationService.NavigateToLocalPage(tempFilePath);
-        #elif QA
-        navigationService.Navigate($"http://local-folder.lambdatest.com/{fileName}");
+        #elif QASAFARI || QAFIREFOX
+        Logger.LogInformation("BrakePoint: 7 - QASafari");
+        navigationService.Navigate($"{ConfigurationService.GetSection<WebSettings>().ExecutionSettings.FileRemoteLocation}{fileName}");
         #endif
 
         return htmlBody;


### PR DESCRIPTION
When the testing environment is Debug or QA - the files are stored locally, so they will be loaded from the local Temp folder.
When the environment is maintained by a cross-browser service - the file will be loaded from their dedicated path.
Added property for the file path, in cases, when using cross-browser service.