### PR TITLE
Fix exception throw when running via MSTest

### DIFF
--- a/src/Bellatrix.Web/lighthouse/MSTestLighthouseReportsWorkflowPlugin.cs
+++ b/src/Bellatrix.Web/lighthouse/MSTestLighthouseReportsWorkflowPlugin.cs
@@ -35,19 +35,19 @@ public class MSTestLighthouseReportsWorkflowPlugin : Plugin
             lock (_lockObject)
             {
                 var driverExecutablePath = new DirectoryInfo(ExecutionDirectoryResolver.GetDriverExecutablePath());
-                var file = driverExecutablePath.GetFiles("*.report.json", SearchOption.AllDirectories).OrderByDescending(f => f.LastWriteTime).First();
+                var file = driverExecutablePath.GetFiles("*.report.json", SearchOption.AllDirectories).OrderByDescending(f => f.LastWriteTime).FirstOrDefault();
                 if (file != null && file.Exists)
                 {
                     TestContext?.AddResultFile(file.FullName);
                 }
 
-                file = driverExecutablePath.GetFiles("*.report.html", SearchOption.AllDirectories).OrderByDescending(f => f.LastWriteTime).First();
+                file = driverExecutablePath.GetFiles("*.report.html", SearchOption.AllDirectories).OrderByDescending(f => f.LastWriteTime).FirstOrDefault();
                 if (file != null && file.Exists)
                 {
                     TestContext?.AddResultFile(file.FullName);
                 }
 
-                file = driverExecutablePath.GetFiles("*.report.csv", SearchOption.AllDirectories).OrderByDescending(f => f.LastWriteTime).First();
+                file = driverExecutablePath.GetFiles("*.report.csv", SearchOption.AllDirectories).OrderByDescending(f => f.LastWriteTime).FirstOrDefault();
                 if (file != null && file.Exists)
                 {
                     TestContext?.AddResultFile(file.FullName);


### PR DESCRIPTION
Fixes the following exception:

```
 SuccessfullyLoginToMyAccount
   Source: LoginTestsMSTest.cs line 13
   Duration: 16,5 sec

  Message: 
TestCleanup method Bellatrix.Web.Tests.LoginTestsMSTest.CoreTestCleanup threw exception. System.InvalidOperationException: System.InvalidOperationException: Sequence contains no elements.

  Stack Trace: 
ThrowHelper.ThrowNoElementsException()
Enumerable.First[TSource](IEnumerable`1 source)
MSTestLighthouseReportsWorkflowPlugin.PostTestCleanup(Object sender, PluginEventArgs e) line 38
PluginProvider.RaiseTestEvent(EventHandler`1 eventHandler, TestOutcome testOutcome, String testName, MemberInfo testMethodMemberInfo, Type testClassType, List`1 arguments, List`1 categories, List`1 authors, List`1 descriptions, String message, String stackTrace, Exception exception) line 138
PluginProvider.PostTestCleanup(TestOutcome testOutcome, String testName, MemberInfo testMethodMemberInfo, Type testClassType, List`1 arguments, List`1 categories, List`1 authors, List`1 descriptions, String message, String stackTrace, Exception exception) line 102
MSTestBaseTest.CoreTestCleanup() line 113

  Standard Output: 
Start Test LoginTestsMSTest.SuccessfullyLoginToMyAccount
Start Test LoginTestsMSTest.SuccessfullyLoginToMyAccount
Type 'xxx' into control (ID = username)
Type 'xxx' into control (ID = password)
Validate control (InnerText containing Log out) is visible
Click control (InnerText containing Log out)
```

Keeps the changes in sync with the NUnit file.